### PR TITLE
INC-5312 - Missing placeholder when an image wasn't posted

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || '/placeholder.png'}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Providing a placeholder image fallback when one was not posted before -- Closes #2.

Issue on `main`:

<img width="1573" alt="Screen Shot 2022-07-22 at 12 01 09 PM" src="https://user-images.githubusercontent.com/1398/180489798-acb4cc3b-b6ba-4a8d-af10-e3080dc932af.png">

Issue address on `inc-5312-missing-image` (this branch):

<img width="1573" alt="Screen Shot 2022-07-22 at 12 05 59 PM" src="https://user-images.githubusercontent.com/1398/180489824-70537bdf-df63-497e-bb21-5a696c7cf059.png">