### PR TITLE
Mobile profile screen UX Issue

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -127,7 +127,7 @@ class Profile extends React.Component {
       <div className="profile-page">
         <div className="container">
           <div className="row p-4 text-center">
-            <div className="user-info col-xs-12 col-md-8 offset-md-2">
+            <div className="col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}
                 className="user-img"

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
On profile screens, the "follow user" section was set to be at minimum 800 pixels wide, causing issues for mobile users browsing the site. Being the section was centered, it didn't require this extra css, so it was removed.

Screenshot of issue on `main` (in production):

<img width="379" alt="Screen Shot 2022-07-29 at 9 23 39 AM" src="https://user-images.githubusercontent.com/1398/181781051-77b90944-d797-424c-ae58-4c6b5e3305e5.png">


Screenshot of issue being addressed on this branch:

<img width="372" alt="Screen Shot 2022-07-29 at 9 23 49 AM" src="https://user-images.githubusercontent.com/1398/181781076-d09eb5bf-51b4-4eba-935e-c52851383f8d.png">